### PR TITLE
fix(heif)!: Fixed package.json to publish all necessary files

### DIFF
--- a/packages/heif/package.json
+++ b/packages/heif/package.json
@@ -15,13 +15,6 @@
   "homepage": "https://github.com/saschazar21/webassembly",
   "license": "MIT",
   "main": "wasm_heif.js",
-  "directories": {
-    "lib": "lib",
-    "test": "__tests__"
-  },
-  "files": [
-    "lib"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/saschazar21/webassembly.git"


### PR DESCRIPTION
This PR is considered to be a follow-up for #37. It has become necessary, as the `package.json` config failed to publish all necessary files within the `packages/heif` project directory.