### PR TITLE
chore: update README files, globally set Jest timeout

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   testEnvironment: 'node',
+  testTimeout: 15000,
   transform: {
-    '^.+\\.[t|j]sx?$': 'ts-jest'
-  }
+    '^.+\\.[t|j]sx?$': 'ts-jest',
+  },
 };

--- a/packages/avif/README.md
+++ b/packages/avif/README.md
@@ -24,24 +24,24 @@ It supports usage in the browser, in a [Web Worker](https://developer.mozilla.or
 
 ```javascript
 // Node.js
-import wasm_avif from '@saschazar/wasm-avif'
+import wasm_avif from '@saschazar/wasm-avif';
 
 // Web Worker - see: https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts
-importScripts('wasm_webp.js')
+importScripts('wasm_avif.js');
 
 // -------- Browser/Web Worker/Node.js code below --------
 
 // Load encoded AVIF image data in Uint8Array
-const array = new Uint8Array(['some', 'encoded', 'AVIF', 'image', 'data'])
-let result
+const array = new Uint8Array(['some', 'encoded', 'AVIF', 'image', 'data']);
+let result;
 
 // Initialize the WebAssembly Module
 const avifModule = wasm_avif({
   onRuntimeInitialized() {
-    result = avifModule.decode(array, array.length) // decode image data and return a new Uint8Array
-    avifModule.free() // clean up memory after encoding is done
-  }
-})
+    result = avifModule.decode(array, array.length); // decode image data and return a new Uint8Array
+    avifModule.free(); // clean up memory after encoding is done
+  },
+});
 ```
 
 ### Example

--- a/packages/avif/tests/wasm_avif.test.ts
+++ b/packages/avif/tests/wasm_avif.test.ts
@@ -53,8 +53,6 @@ describe('AVIF', () => {
   });
 
   it('decodes an AVIF image', async () => {
-    jest.setTimeout(10000);
-
     const buf = new Uint8Array(
       await fetch(AVIF_TEST_IMAGE).then(res => res.buffer())
     );
@@ -68,7 +66,6 @@ describe('AVIF', () => {
   });
 
   // it('encodes an AVIF image', async () => {
-  //   jest.setTimeout(20000);
   //   const options: EncodeOptions = defaultOptions;
   //   const [inWidth, inHeight] = [3000, 2000];
   //   const buf = new Uint8Array(

--- a/packages/mozjpeg/README.md
+++ b/packages/mozjpeg/README.md
@@ -24,27 +24,28 @@ It supports usage in the browser, in a [Web Worker](https://developer.mozilla.or
 
 ```javascript
 // Node.js
-import wasm_mean_color from '@saschazar/wasm-mozjpeg'
+import wasm_mozjpeg from '@saschazar/wasm-mozjpeg';
+import defaultOptions from '@saschazar/wasm-mozjpeg/options';
 
 // Web Worker - see: https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts
-importScripts('wasm_mozjpeg.js')
+importScripts('wasm_mozjpeg.js');
 
 // -------- Browser/Web Worker/Node.js code below --------
 
 // Load raw RGB image data in Uint8Array (e.g. consistently chained [R][G][B] data)
-const array = new Uint8Array(['some', 'raw', 'RGB', 'image', 'data'])
-const width = 800 // the image's width
-const height = 600 // the image's height
-const options = {} // MozJPEG's options
-let result
+const array = new Uint8Array(['some', 'raw', 'RGB', 'image', 'data']);
+const width = 800; // the image's width
+const height = 600; // the image's height
+const options = defaultOptions; // MozJPEG's options, complete object crucially needed!
+let result;
 
 // Initialize the WebAssembly Module
 const mozjpegModule = wasm_mozjpeg({
   onRuntimeInitialized() {
-    result = mozjpegModule.encode(array, width, height, options) // encode image data and return a new Uint8Array
-    mozjpegModule.free() // clean up memory after encoding is done
-  }
-})
+    result = mozjpegModule.encode(array, width, height, options); // encode image data and return a new Uint8Array
+    mozjpegModule.free(); // clean up memory after encoding is done
+  },
+});
 ```
 
 ### Example
@@ -53,7 +54,7 @@ A working example is available on [RunKit](https://runkit.com/saschazar21/5e8746
 
 ### Options
 
-It's crucial to provide a full options object, to gain the best possible outcome. The default options object may be imported from the `options.js` file.
+⚠️ It's crucial to provide a full options object. The default options object may be imported from the `options.js` file.
 
 ## Credits
 

--- a/packages/mozjpeg/tests/wasm_mozjpeg.test.ts
+++ b/packages/mozjpeg/tests/wasm_mozjpeg.test.ts
@@ -16,7 +16,7 @@ describe('MozJPEG', () => {
   });
 
   beforeAll(async () => {
-    mozJPEGModule = (await new Promise((resolve) => {
+    mozJPEGModule = (await new Promise(resolve => {
       const wasm = wasm_mozjpeg({
         noInitialRun: true,
         onRuntimeInitialized() {
@@ -26,7 +26,7 @@ describe('MozJPEG', () => {
       });
     })) as MozJPEGModule;
 
-    imageLoaderModule = (await new Promise((resolve) => {
+    imageLoaderModule = (await new Promise(resolve => {
       const wasm = wasm_image_loader({
         noInitialRun: true,
         onRuntimeInitialized() {
@@ -38,14 +38,13 @@ describe('MozJPEG', () => {
   });
 
   it('encodes an image to .jpeg', async () => {
-    jest.setTimeout(10000);
     const [inWidth, inHeight] = [6000, 4000];
     const options: MozJPEGOptions = { ...defaultOptions, quality: 75 };
 
     const img = new Uint8Array(
-      await fetch(`${RANDOM_URL}${inWidth}x${inHeight}`, {}).then((res) =>
-        res.buffer(),
-      ),
+      await fetch(`${RANDOM_URL}${inWidth}x${inHeight}`, {}).then(res =>
+        res.buffer()
+      )
     );
     const { decode, resize } = imageLoaderModule;
     const { encode } = mozJPEGModule;
@@ -58,8 +57,8 @@ describe('MozJPEG', () => {
         inHeight,
         3,
         inWidth * 0.25,
-        inHeight * 0.25,
-      ) as Uint8Array,
+        inHeight * 0.25
+      ) as Uint8Array
     );
     expect(resized).toHaveLength(inWidth * 0.25 * (inHeight * 0.25) * 3);
 
@@ -67,7 +66,7 @@ describe('MozJPEG', () => {
       resized,
       inWidth * 0.25,
       inHeight * 0.25,
-      options,
+      options
     ) as Uint8Array;
 
     expect(result.length).toBeGreaterThan(0);

--- a/packages/webp/README.md
+++ b/packages/webp/README.md
@@ -24,27 +24,28 @@ It supports usage in the browser, in a [Web Worker](https://developer.mozilla.or
 
 ```javascript
 // Node.js
-import wasm_webp from '@saschazar/wasm-webp'
+import wasm_webp from '@saschazar/wasm-webp';
+import defaultOptions from '@saschazar/wasm-webp/options';
 
 // Web Worker - see: https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope/importScripts
-importScripts('wasm_webp.js')
+importScripts('wasm_webp.js');
 
 // -------- Browser/Web Worker/Node.js code below --------
 
 // Load raw RGB image data in Uint8Array (e.g. consistently chained [R][G][B] data)
-const array = new Uint8Array(['some', 'raw', 'RGB', 'image', 'data'])
-const width = 800 // the image's width
-const height = 600 // the image's height
-const options = {} // WebP's options
-let result
+const array = new Uint8Array(['some', 'raw', 'RGB', 'image', 'data']);
+const width = 800; // the image's width
+const height = 600; // the image's height
+const options = defaultOptions; // WebP's options, a complete object is crucially needed!
+let result;
 
 // Initialize the WebAssembly Module
 const webpModule = wasm_webp({
   onRuntimeInitialized() {
-    result = webpModule.encode(array, width, height, options) // encode image data and return a new Uint8Array
-    webpModule.free() // clean up memory after encoding is done
-  }
-})
+    result = webpModule.encode(array, width, height, options); // encode image data and return a new Uint8Array
+    webpModule.free(); // clean up memory after encoding is done
+  },
+});
 ```
 
 ### Example
@@ -53,7 +54,7 @@ A working example is available on [RunKit](https://runkit.com/saschazar21/5e8713
 
 ### Options
 
-It's crucial to provide a full options object, to gain the best possible outcome. The default options object may be imported from the `options.js` file.
+⚠️ It's crucial to provide a complete options object. The default options object may be imported from the `options.js` file.
 
 ## Credits
 

--- a/packages/webp/tests/wasm_webp.test.ts
+++ b/packages/webp/tests/wasm_webp.test.ts
@@ -16,7 +16,7 @@ describe('WebP', () => {
   });
 
   beforeAll(async () => {
-    imageLoaderModule = (await new Promise((resolve) => {
+    imageLoaderModule = (await new Promise(resolve => {
       const wasm = wasm_image_loader({
         noInitialRun: true,
         onRuntimeInitialized() {
@@ -26,7 +26,7 @@ describe('WebP', () => {
       });
     })) as ImageLoaderModule;
 
-    webpModule = (await new Promise((resolve) => {
+    webpModule = (await new Promise(resolve => {
       const wasm = wasm_webp({
         noInitialRun: true,
         onRuntimeInitialized() {
@@ -38,22 +38,21 @@ describe('WebP', () => {
   });
 
   it('encodes a .jpeg into .webp', async () => {
-    jest.setTimeout(10000);
     const options: EncodeOptions = {
       ...defaultOptions,
       quality: 80.0,
     };
     const [inWidth, inHeight] = [3000, 2000];
     const buf = new Uint8Array(
-      await fetch(`${RANDOM_URL}${inWidth}x${inHeight}`, {}).then((res) =>
-        res.buffer(),
-      ),
+      await fetch(`${RANDOM_URL}${inWidth}x${inHeight}`, {}).then(res =>
+        res.buffer()
+      )
     );
     const { decode: jpegDecode, resize } = imageLoaderModule;
     const { encode } = webpModule;
 
     const decoded = new Uint8Array(
-      jpegDecode(buf, buf.length, 0) as Uint8Array,
+      jpegDecode(buf, buf.length, 0) as Uint8Array
     );
     const resized = new Uint8Array(
       resize(
@@ -62,15 +61,15 @@ describe('WebP', () => {
         inHeight,
         3,
         inWidth * 0.75,
-        inHeight * 0.75,
-      ) as Uint8Array,
+        inHeight * 0.75
+      ) as Uint8Array
     );
 
     const output = encode(
       resized,
       inWidth * 0.75,
       inHeight * 0.75,
-      options,
+      options
     ) as Uint8Array;
     expect(output.length).toBeLessThan(inWidth * 0.75 * (inHeight * 0.75) * 3);
   });
@@ -82,15 +81,15 @@ describe('WebP', () => {
     };
     const [inWidth, inHeight] = [800, 600];
     const buf = new Uint8Array(
-      await fetch(`${RANDOM_URL}${inWidth}x${inHeight}`, {}).then((res) =>
-        res.buffer(),
-      ),
+      await fetch(`${RANDOM_URL}${inWidth}x${inHeight}`, {}).then(res =>
+        res.buffer()
+      )
     );
     const { decode: jpegDecode } = imageLoaderModule;
     const { dimensions, decode, encode } = webpModule;
 
     const decoded = new Uint8Array(
-      jpegDecode(buf, buf.length, 0) as Uint8Array,
+      jpegDecode(buf, buf.length, 0) as Uint8Array
     );
 
     const encoded = encode(decoded, inWidth, inHeight, options) as Uint8Array;

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,7 +16,7 @@
     parse-commit-message "4.0.0"
     tslib "1.11.1"
 
-"@auto-it/core@^9.24.0", "@auto-it/core@^9.26.7":
+"@auto-it/core@^9.26.7":
   version "9.26.7"
   resolved "https://registry.yarnpkg.com/@auto-it/core/-/core-9.26.7.tgz#69bef507ca1356660d2fc4df64cab4cf151c0a81"
   integrity sha512-WbmvO++zwxEcPoS9RMDW27TSUnhfAiSeKFGwGoYPj8gsZh4gKxvDCu5QmbNW6cPy6+XqKHW2Gj7UdlLl+P6phw==
@@ -2210,16 +2210,6 @@
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.26.0":
-  version "2.26.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.26.0.tgz#063390c404d9980767d76274df386c0aa675d91d"
-  integrity sha512-RELVoH5EYd+JlGprEyojUv9HeKcZqF7nZUGSblyAw1FwOGNnmQIU8kxJ69fttQvEwCsX5D6ECJT8GTozxrDKVQ==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.26.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-
 "@typescript-eslint/experimental-utils@2.27.0", "@typescript-eslint/experimental-utils@^2.5.0":
   version "2.27.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.27.0.tgz#801a952c10b58e486c9a0b36cf21e2aab1e9e01a"
@@ -2239,19 +2229,6 @@
     "@typescript-eslint/experimental-utils" "2.27.0"
     "@typescript-eslint/typescript-estree" "2.27.0"
     eslint-visitor-keys "^1.1.0"
-
-"@typescript-eslint/typescript-estree@2.26.0":
-  version "2.26.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.26.0.tgz#d8132cf1ee8a72234f996519a47d8a9118b57d56"
-  integrity sha512-3x4SyZCLB4zsKsjuhxDLeVJN6W29VwBnYpCsZ7vIdPel9ZqLfIZJgJXO47MNUkurGpQuIBALdPQKtsSnWpE1Yg==
-  dependencies:
-    debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^6.3.0"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@2.27.0":
   version "2.27.0"


### PR DESCRIPTION
This PR updates information in some `README` files to fix examples, as well as typos.

Furthermore, individual `jest.setTimeout()` have been replaced in favor of a global `testTimeout` setting in the `jest.config.js` file.