### PR TITLE
feat(avif): updated libavif, dav1d version

### DIFF
--- a/packages/avif/build.sh
+++ b/packages/avif/build.sh
@@ -10,7 +10,7 @@ export CPPFLAGS="${OPTIMIZE}"
 export RUST_WASM32_TARGET=wasm32-unknown-emscripten
 export RUSTFLAGS="-C target-cpu=generic -C link-arg=-s"
 
-export DAV1D_DOWNLOAD="https://github.com/videolan/dav1d/archive/0.6.0.tar.gz"
+export DAV1D_DOWNLOAD="https://github.com/videolan/dav1d/archive/0.7.1.tar.gz"
 export RAV1E_DOWNLOAD="https://github.com/xiph/rav1e/archive/v0.3.1.tar.gz"
 
 export CMAKE_TOOLCHAIN_FILE=/emsdk_portable/emscripten/sdk/cmake/Modules/Platform/Emscripten.cmake

--- a/packages/avif/main.cpp
+++ b/packages/avif/main.cpp
@@ -148,7 +148,7 @@ EMSCRIPTEN_BINDINGS(AVIF)
       .value("AVIF_PIXEL_FORMAT_YUV444", avifPixelFormat::AVIF_PIXEL_FORMAT_YUV444)
       .value("AVIF_PIXEL_FORMAT_YUV422", avifPixelFormat::AVIF_PIXEL_FORMAT_YUV422)
       .value("AVIF_PIXEL_FORMAT_YUV420", avifPixelFormat::AVIF_PIXEL_FORMAT_YUV420)
-      .value("AVIF_PIXEL_FORMAT_YV12", avifPixelFormat::AVIF_PIXEL_FORMAT_YV12);
+      .value("AVIF_PIXEL_FORMAT_YUV400", avifPixelFormat::AVIF_PIXEL_FORMAT_YUV400);
 
   value_object<avifEncoder>("EncodeOptions")
       .field("minQuantizer", &avifEncoder::minQuantizer)

--- a/packages/avif/package.json
+++ b/packages/avif/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "napa && docker run --rm -v $(pwd):/src -e SKIP_LIBAVIF=$SKIP_LIBAVIF trzeci/emscripten:1.39.18-fastcomp ./build.sh"
+    "build": "napa && docker run --rm -v $(pwd):/src -e SKIP_LIBAVIF=$SKIP_LIBAVIF trzeci/emscripten:1.39.18-upstream ./build.sh"
   },
   "napa": {
     "libavif": "AOMediaCodec/libavif#v0.8.0"

--- a/packages/avif/package.json
+++ b/packages/avif/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "napa && docker run --rm -v $(pwd):/src -e SKIP_LIBAVIF=$SKIP_LIBAVIF trzeci/emscripten:1.39.18-upstream ./build.sh"
+    "build": "napa && docker run --rm -v $(pwd):/src -e SKIP_LIBAVIF=$SKIP_LIBAVIF trzeci/emscripten:1.39.10-fastcomp ./build.sh"
   },
   "napa": {
     "libavif": "AOMediaCodec/libavif#v0.8.0"

--- a/packages/avif/package.json
+++ b/packages/avif/package.json
@@ -27,10 +27,10 @@
     "access": "public"
   },
   "scripts": {
-    "build": "napa && docker run --rm -v $(pwd):/src -e SKIP_LIBAVIF=$SKIP_LIBAVIF trzeci/emscripten:1.39.10-fastcomp ./build.sh"
+    "build": "napa && docker run --rm -v $(pwd):/src -e SKIP_LIBAVIF=$SKIP_LIBAVIF trzeci/emscripten:1.39.18-fastcomp ./build.sh"
   },
   "napa": {
-    "libavif": "AOMediaCodec/libavif#v0.6.3"
+    "libavif": "AOMediaCodec/libavif#v0.8.0"
   },
   "devDependencies": {
     "napa": "^3.0.0"

--- a/packages/avif/wasm_avif.d.ts
+++ b/packages/avif/wasm_avif.d.ts
@@ -5,7 +5,7 @@ export enum AVIF_PIXEL_FORMAT {
   AVIF_PIXEL_FORMAT_YUV444, // default
   AVIF_PIXEL_FORMAT_YUV422,
   AVIF_PIXEL_FORMAT_YUV420,
-  AVIF_PIXEL_FORMAT_YV12,
+  AVIF_PIXEL_FORMAT_YUV400,
 }
 
 export interface Dimensions {
@@ -30,4 +30,4 @@ export interface AVIFModule extends EmscriptenModule {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default function(options: { [key: string]: any }): AVIFModule;
+export default function (options: { [key: string]: any }): AVIFModule;


### PR DESCRIPTION
This updates [AOMediaCoded/libavif](https://github.com/AOMediaCodec/libavif) to `v0.8.0`, and [videolan/dav1d](https://github.com/videolan/dav1d) to `v0.7.1`.

Due to an update in the `AVIF_PIXEL_FORMAT`s, this is a **BREAKING CHANGE**.