### PR TITLE
feat(mozjpeg): bumped MozJPEG version to 4.0.3

### DIFF
--- a/packages/mozjpeg/package.json
+++ b/packages/mozjpeg/package.json
@@ -26,7 +26,7 @@
     "build": "napa && docker run --rm -v $(pwd):/src -e SKIP_MOZJPEG=$SKIP_MOZJPEG emscripten/emsdk:latest ./build.sh"
   },
   "napa": {
-    "mozjpeg": "mozilla/mozjpeg#v4.0.2"
+    "mozjpeg": "mozilla/mozjpeg#v4.0.3"
   },
   "devDependencies": {
     "napa": "^3.0.0"


### PR DESCRIPTION
https://github.com/mozilla/mozjpeg library version is now at 4.0.3

This PR should trigger a new `@saschazar/wasm-mozjpeg` version.