### PR TITLE
fix(webp): downgraded libwebp to 1.1.0 due to image quality issues

### DIFF
--- a/packages/webp/main.cpp
+++ b/packages/webp/main.cpp
@@ -84,6 +84,10 @@ val encode(std::string img_in, int _width, int _height, int _channels, WebPConfi
   row_stride = width * channels;
   length = height * row_stride;
 
+  if (!WebPValidateConfig(&config)) {
+    throw std::runtime_error("WebP config is invalid!");
+  }
+
   if (!WebPPictureInit(&webp))
   {
     throw std::runtime_error("WebP picture init failed!");

--- a/packages/webp/package.json
+++ b/packages/webp/package.json
@@ -27,7 +27,7 @@
     "build": "napa && docker run --rm -v $(pwd):/src -e SKIP_LIBWEBP=$SKIP_LIBWEBP emscripten/emsdk:latest ./build.sh"
   },
   "napa": {
-    "libwebp": "webmproject/libwebp#v1.2.0"
+    "libwebp": "webmproject/libwebp#v1.1.0"
   },
   "devDependencies": {
     "napa": "^3.0.0"


### PR DESCRIPTION
Since https://github.com/webmproject/libwebp/releases/tag/v1.2.0 seems to have issues accepting the `quality` parameter of the WebP config object, `libwebp` has been downgraded to the previously used `v1.1.0` tag: https://github.com/webmproject/libwebp/releases/tag/v1.1.0

Additionally, the `WebPValidateConfig` check has been added to the `encode` function: https://github.com/webmproject/libwebp/blob/v1.1.0/src/webp/encode.h#L197