### PR TITLE
chore: updated node versions in Github workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 12.x
 
       - name: Cache node modules
         uses: actions/cache@v2
@@ -56,7 +56,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - name: Check out the repo


### PR DESCRIPTION
This PR removes `node v10.x` from the supported Node versions in the `build-and-test` Github workflow. Furthermore, `node v16.x` has been added.