### PR TITLE
fix(avif): updated AOM codec to v3.2.0, libavif to v0.9.2

### DIFF
--- a/packages/avif/build.sh
+++ b/packages/avif/build.sh
@@ -7,7 +7,7 @@ export LDFLAGS="${OPTIMIZE}"
 export CFLAGS="${OPTIMIZE}"
 export CPPFLAGS="${OPTIMIZE}"
 
-export AOM_DOWNLOAD="https://aomedia.googlesource.com/aom/+archive/cb1d48da8da2061e72018761788a18b8fa8013bb.tar.gz" #v2.0.2
+export AOM_DOWNLOAD="https://aomedia.googlesource.com/aom/+archive/287164de79516c25c8c84fd544f67752c170082a.tar.gz" #v3.2.0
 
 export CMAKE_TOOLCHAIN_FILE=/emsdk/upstream/emscripten/cmake/Modules/Platform/Emscripten.cmake
 

--- a/packages/avif/package.json
+++ b/packages/avif/package.json
@@ -32,7 +32,7 @@
     "build": "napa && docker run --rm -v $(pwd):/src -e SKIP_LIBAVIF=$SKIP_LIBAVIF emscripten/emsdk:latest ./build.sh"
   },
   "napa": {
-    "libavif": "AOMediaCodec/libavif#v0.9.0"
+    "libavif": "AOMediaCodec/libavif#v0.9.2"
   },
   "devDependencies": {
     "napa": "^3.0.0"


### PR DESCRIPTION
This PR updates `libaom` to `v3.2.0` and `libavif` to `v0.9.2`.