### PR TITLE
Fix deadlock issue with example code in wasm-heif README.md

### DIFF
--- a/packages/heif/README.md
+++ b/packages/heif/README.md
@@ -30,19 +30,21 @@ import wasm_heif from '@saschazar/wasm-heif';
 importScripts('wasm_heif.js');
 
 // -------- Browser/Web Worker/Node.js code below --------
+(async function() {
+  // Load encoded HEIF image data in Uint8Array
+  const array = new Uint8Array(['some', 'encoded', 'heif', 'image', 'data']);
+  let result;
 
-// Load encoded HEIF image data in Uint8Array
-const array = new Uint8Array(['some', 'encoded', 'heif', 'image', 'data']);
-let result;
-
-// Initialize the WebAssembly Module
-const heifModule = wasm_heif({
-  onRuntimeInitialized() {
-    const alpha = false; // RGBA somehow not yet working ¯\_(ツ)_/¯
-    result = heifModule.decode(array, array.length, alpha); // decode image data and return a new Uint8Array
-    heifModule.free(); // clean up memory after encoding is done
-  },
-});
+  // Initialize the WebAssembly Module
+  const heifModule = await wasm_heif({
+    onRuntimeInitialized() {
+      console.log('Runtime Initialized');
+    },
+  });
+  const alpha = false; // RGBA somehow not yet working ¯\_(ツ)_/¯
+  result = heifModule.decode(array, array.length, alpha); // decode image data and return a new Uint8Array
+  heifModule.free(); // clean up memory after encoding is done
+})();
 ```
 
 ### ⚠️ Support


### PR DESCRIPTION
I spent a long time debugging the sample code at [npm:@saschazar/wasm-heif](https://www.npmjs.com/package/@saschazar/wasm-heif). It just deadlocks in `heifModule.decode()` without any output.

![0e0c0d1e-22fc-4f67-b680-9c8ddf662e8d](https://user-images.githubusercontent.com/4986069/149567961-bf1137de-ba69-4673-841e-ec31721345d9.png)

In the end I found out that this is because we cannot call `heifModule.decode()` in `onRuntimeInitialized()`. If I move it outside, everything works fine.

![bce4ff20-a90e-48c0-94aa-7950bb182231](https://user-images.githubusercontent.com/4986069/149567975-3d51540c-7a4a-46b3-9b60-7d9d9b9285b1.png)
