### PR TITLE
heif: initialize image pointer

### DIFF
--- a/packages/heif/main.cpp
+++ b/packages/heif/main.cpp
@@ -4,7 +4,7 @@
 
 using namespace emscripten;
 
-uint8_t *image;
+uint8_t *image = NULL;
 uint32_t width;
 uint32_t height;
 uint32_t length;
@@ -22,6 +22,7 @@ void free_buffer()
   if (image != NULL)
   {
     delete[] image;
+    image = NULL;
   }
 }
 

--- a/packages/heif/package.json
+++ b/packages/heif/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@saschazar/wasm-heif",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A WebAssembly powered HEIF/HEIC decoder",
   "keywords": [
     "heif",
@@ -20,7 +20,7 @@
     "url": "git+https://github.com/saschazar21/webassembly.git"
   },
   "scripts": {
-    "build": "napa && docker run --rm -v $(pwd):/src -e SKIP_LIBHEIF=$SKIP_LIBHEIF emscripten/emsdk:latest ./build.sh"
+    "build": "napa && docker run --rm -v $(pwd):/src -e SKIP_LIBHEIF=$SKIP_LIBHEIF emscripten/emsdk:2.0.34 ./build.sh"
   },
   "bugs": {
     "url": "https://github.com/saschazar21/webassembly/issues"


### PR DESCRIPTION
In `heif/main.cpp` the image pointer is not initialized, which could cause a memory access violation. `free_buffer` doesn't set the image pointer to `NULL` and calling `free_buffer` two times will cause a memory access violation.
Also, set an explicit emsdk tag, because the library won't build with the latest version of the SDK.